### PR TITLE
Add composer.json for aws-sdk requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "aws/aws-sdk-php": "3.x"
+    }
+}


### PR DESCRIPTION
This allows me to use mediawiki's composer.local.json to include this
dependency.